### PR TITLE
update duphold version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update -y && apt-get install -y \
     wget 
 
 ENV DUPHOLD_INSTALL_DIR=/opt/duphold
-ENV DUPHOLD_VERSION=0.1.4
+ENV DUPHOLD_VERSION=0.15
 
 RUN mkdir $DUPHOLD_INSTALL_DIR
 WORKDIR $DUPHOLD_INSTALL_DIR


### PR DESCRIPTION
Upgrading to `v0.1.5` This contains the fix to properly annotate svs with alts set as `<DUP:TANDEM>`

the GitHub link for duphold static download has a typo of `v0.15` instead of `v0.1.5`